### PR TITLE
Bug fixes

### DIFF
--- a/fork.c
+++ b/fork.c
@@ -12,16 +12,13 @@
 void forkit(char **paths, char **tokens)
 {
 	pid_t cpid;
-	int status, strcheck, i = 0;
+	int status, i = 0;
 	char temp_path[128];
 	extern char **environ;
 
 	if (access(tokens[0], X_OK) == 0)
-	{
 		strcpy(temp_path, tokens[0]);
-		strcheck = strcmp(temp_path, tokens[0]);
-	}
-	if (strcheck != 0)
+	if (temp != tokens[0])
 	{
 		while (paths[i] != NULL)
 		{

--- a/functions.c
+++ b/functions.c
@@ -81,7 +81,7 @@ void free_array(char **array)
 
 char *space_check(char *str)
 {
-	int i = 0;
+	int i = 0, j = 0;
 	int space_count = 0;
 	int nonspace = 0;
 	int str_len = strlen(str);
@@ -110,7 +110,8 @@ char *space_check(char *str)
 		else{
 			space_count = 0;
 			nonspace++;
-			newstr[i] = str[i];
+			newstr[j] = str[i];
+			j++;
 		}
 		i++;
 	}

--- a/shell.c
+++ b/shell.c
@@ -30,7 +30,7 @@ int main(void)
 		strcheck = space_check(buffer);
 		if (strcmp(strcheck, " ") == 0)
 			continue;
-		tokens = tokenize(buffer, " ");
+		tokens = tokenize(strcheck, " ");
 		fflush(stdout);
 		forkit(paths, tokens);
 		free_array(tokens);


### PR DESCRIPTION
Small fix to the way tokenize is called in shell.c - pass in the strcheck string instead of the raw buffer string

Iteration fix to space_check function in functions.c - use iterator variable 'j' for newstr, instead of reusing i

Revert previous change to fork.c