### PR TITLE
Cody working

### DIFF
--- a/fork.c
+++ b/fork.c
@@ -20,9 +20,14 @@ void forkit(char **paths, char **tokens)
 		strcpy(temp_path, tokens[0]);
 		i = 100;
 	}
-	if (i != 100)
+	if (i != 100 && paths != NULL)
 	{
 		set_path(temp_path, paths, tokens);
+	}
+	else if (i != 100 && paths == NULL)
+	{
+		perror("");
+		exit(127);
 	}
 	if (access(temp_path, X_OK) == 0)
 	{
@@ -31,7 +36,7 @@ void forkit(char **paths, char **tokens)
 	else
 	{
 	perror("");
-	exit(1);
+	exit(127);
 	}
 }
 void set_path(char *temp_path, char **paths, char **tokens)

--- a/functions.c
+++ b/functions.c
@@ -16,7 +16,7 @@ char **tokenize(char *str, char *delim)
 
 	if (str == NULL)
 	{
-		exit(1);
+		return (0);
 	}
 	if (!tokens)
 	{
@@ -71,12 +71,15 @@ int exit_check(char *buff)
 void free_array(char **array)
 {
 	int i = 0;
-	while (array[i] != NULL)
+	if (array != NULL)
 	{
-		free(array[i]);
-		i++;
+		while (array[i] != NULL)
+		{
+			free(array[i]);
+			i++;
+		}
+		free(array);
 	}
-	free(array);
 }
 
 char *space_check(char *str)

--- a/shell.c
+++ b/shell.c
@@ -28,13 +28,14 @@ int main(void)
 		if (exit_check(buffer) == 1 || feof(stdin) != 0)
 			break;
 		strcheck = space_check(buffer);
-		if (strcmp(strcheck, " ") == 0 || strcmp(strcheck, "") == 0)
-			continue;
-		tokens = tokenize(strcheck, " ");
-		fflush(stdout);
-		forkit(paths, tokens);
-		free_array(tokens);
-		tokens = NULL;
+		if (strcmp(strcheck, " ") != 0 && strcmp(strcheck, "") != 0)
+		{
+			tokens = tokenize(strcheck, " ");
+			fflush(stdout);
+			forkit(paths, tokens);
+			free_array(tokens);
+			tokens = NULL;
+		}
 		free(strcheck);
 		strcheck = NULL;
 	}
@@ -42,6 +43,7 @@ int main(void)
 	free_array(paths);
 	free(buffer);
 	free(strcheck);
-	free(path);
+	if (path != NULL)
+		free(path);
 	exit(0);
 }


### PR DESCRIPTION
Fixed strcheck causing a memory leak in function main - altered loop to free the string on each iteration.

Fixed a check in function tokenize that could cause the shell to exit erroneously if attempting to tokenize a NULL string, as in the case of a nonexistent path.

Fixed a check in function forkit that would cause valid commands (e.g. /bin/ls) to fail when the provided path string is NULL.